### PR TITLE
Updates Annotations to set the property when brought back into view

### DIFF
--- a/TAKAware/Screens/MainScreens/MapView.swift
+++ b/TAKAware/Screens/MainScreens/MapView.swift
@@ -460,6 +460,7 @@ struct MapView: UIViewRepresentable {
                 bloodhoundStartCoordinate = nil
                 bloodhoundEndCoordinate = nil
                 bloodhoundEndAnnotation = nil
+                viewModel.isAcquiringBloodhoundTarget = false
             }
         }
     }
@@ -595,20 +596,21 @@ struct MapView: UIViewRepresentable {
                     annotation: mpAnnotation,
                     reuseIdentifier: identifier
                 )
-
-                let icon = IconData.iconFor(type2525: mpAnnotation.cotType ?? "", iconsetPath: mpAnnotation.icon ?? "")
-                var pointIcon: UIImage = icon.icon
-                
-                if let pointColor = mpAnnotation.color {
-                    if pointIcon.isSymbolImage {
-                        pointIcon = pointIcon.maskSymbol(with: pointColor)
-                    } else {
-                        pointIcon = pointIcon.maskImage(with: pointColor)
-                    }
-                }
-                
-                annotationView!.image = pointIcon
             }
+
+            let icon = IconData.iconFor(type2525: mpAnnotation.cotType ?? "", iconsetPath: mpAnnotation.icon ?? "")
+            var pointIcon: UIImage = icon.icon
+            
+            if let pointColor = mpAnnotation.color {
+                if pointIcon.isSymbolImage {
+                    pointIcon = pointIcon.maskSymbol(with: pointColor)
+                } else {
+                    pointIcon = pointIcon.maskImage(with: pointColor)
+                }
+            }
+            
+            annotationView!.image = pointIcon
+            annotationView!.annotation = mpAnnotation
             return annotationView
         }
     }


### PR DESCRIPTION
We were relying on the behavior of the annotation property of the view to be set when created, but that doesn't work when the view is reused. 

Closes #29 which was caused by the annotation view being linked to the wrong annotation