### PR TITLE
Adds extra guard check for potential crash

### DIFF
--- a/TAKAware/Screens/MainScreens/MapView.swift
+++ b/TAKAware/Screens/MainScreens/MapView.swift
@@ -368,7 +368,7 @@ struct MapView: UIViewRepresentable {
         
         let existingAnnotations = mapView.annotations.filter { $0 is MapPointAnnotation }
         let current = Set(existingAnnotations.map { ($0 as! MapPointAnnotation).id })
-        let new = Set(incomingData.map { $0.id!.uuidString })
+        let new = Set(incomingData.map { $0.id?.uuidString ?? "" }.filter { !$0.isEmpty })
         let toRemove = Array(current.symmetricDifference(new))
         let toAdd = Array(new.symmetricDifference(current))
 


### PR DESCRIPTION
Closes #30 

In this crash report the error occurred during updates of map annotations. There are very few places where we are unwrapping an optional, generally all guarded prior. However one place was in the ID coming back from a database entry. So this guards for that case and rejects that annotation.