### PR TITLE
Remote Data Package Management

### DIFF
--- a/TAKAware.xcodeproj/project.pbxproj
+++ b/TAKAware.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		A578E42E2C550FD8001978D4 /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A578E42D2C550FD8001978D4 /* MapView.swift */; };
 		A578E4382C55B3E1001978D4 /* DataSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A578E4372C55B3E1001978D4 /* DataSyncManager.swift */; };
 		A578E43E2C56E97A001978D4 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A578E43D2C56E97A001978D4 /* Launch Screen.storyboard */; };
+		A59530FC2CF7EFB00078C1E8 /* DataPackageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59530FB2CF7EFA30078C1E8 /* DataPackageManager.swift */; };
 		A595F6682C278CCD00E81976 /* AwarenessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A595F6672C278CCD00E81976 /* AwarenessView.swift */; };
 		A595F66A2C278CFE00E81976 /* Components.swift in Sources */ = {isa = PBXBuildFile; fileRef = A595F6692C278CFE00E81976 /* Components.swift */; };
 		A59C08472AACF95100C33B44 /* CertificateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59C08462AACF95100C33B44 /* CertificateManager.swift */; };
@@ -3455,6 +3456,7 @@
 		A578E43D2C56E97A001978D4 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
 		A58B372C2A57B0390002B984 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		A58B372D2A57B38A0002B984 /* LICENSE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = LICENSE.md; sourceTree = "<group>"; };
+		A59530FB2CF7EFA30078C1E8 /* DataPackageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataPackageManager.swift; sourceTree = "<group>"; };
 		A595F6672C278CCD00E81976 /* AwarenessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AwarenessView.swift; sourceTree = "<group>"; };
 		A595F6692C278CFE00E81976 /* Components.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Components.swift; sourceTree = "<group>"; };
 		A599D66C2A5E45CD00B507D9 /* TAKAware.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TAKAware.entitlements; sourceTree = "<group>"; };
@@ -10317,6 +10319,7 @@
 		A5E2F8FC2A791F0600EDD0B4 /* Communications */ = {
 			isa = PBXGroup;
 			children = (
+				A59530FB2CF7EFA30078C1E8 /* DataPackageManager.swift */,
 				A5BF02012A5EBCA40043065B /* TCPMessage.swift */,
 				A5BF01FF2A5EB63F0043065B /* UDPMessage.swift */,
 				A5FB4E632A8FE0020034966D /* CSRRequestor.swift */,
@@ -13954,6 +13957,7 @@
 				A595F6682C278CCD00E81976 /* AwarenessView.swift in Sources */,
 				A55ABF532ABDC11900195AB7 /* AboutInformation.swift in Sources */,
 				A55ABF512ABDC0E900195AB7 /* MapOptions.swift in Sources */,
+				A59530FC2CF7EFB00078C1E8 /* DataPackageManager.swift in Sources */,
 				A5D8D37E2A53B0F9002F0E3E /* TAKAwareApp.swift in Sources */,
 				A5B312BB2C38C5A6007B3914 /* COTData.xcdatamodeld in Sources */,
 				A5E7B00B2A70B5FA00D9203F /* TAKDataPackageParser.swift in Sources */,
@@ -14167,7 +14171,7 @@
 				CODE_SIGN_ENTITLEMENTS = TAKAware/TAKAware.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				DEVELOPMENT_ASSET_PATHS = "TAKAware/Preview\\ Content";
 				DEVELOPMENT_TEAM = 28788VBS76;
 				ENABLE_PREVIEWS = YES;
@@ -14211,7 +14215,7 @@
 				CODE_SIGN_ENTITLEMENTS = TAKAware/TAKAware.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				DEVELOPMENT_ASSET_PATHS = "TAKAware/Preview\\ Content";
 				DEVELOPMENT_TEAM = 28788VBS76;
 				ENABLE_PREVIEWS = YES;
@@ -14251,7 +14255,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				DEVELOPMENT_TEAM = 5LZ5HR44P3;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -14272,7 +14276,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				DEVELOPMENT_TEAM = 5LZ5HR44P3;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -14291,7 +14295,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				DEVELOPMENT_TEAM = 5LZ5HR44P3;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.1;
@@ -14308,7 +14312,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 31;
+				CURRENT_PROJECT_VERSION = 32;
 				DEVELOPMENT_TEAM = 5LZ5HR44P3;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.1;

--- a/TAKAware/Communications/DataPackageManager.swift
+++ b/TAKAware/Communications/DataPackageManager.swift
@@ -62,6 +62,8 @@ class DataPackageManager: NSObject, ObservableObject, URLSessionDelegate {
     @Published var dataPackages: [TAKMissionPackage] = []
     @Published var isLoading = false
     @Published var isSendingUpdate = false
+    @Published var isFinishedProcessingRemotePackage = false
+    @Published var remotePackageProcessStatus: String = ""
     let ANON_CHANNEL_NAME = "__ANON__"
     
     func retrieveDataPackages() {
@@ -157,6 +159,8 @@ class DataPackageManager: NSObject, ObservableObject, URLSessionDelegate {
     }
     
     func importRemotePackage(missionPackage: TAKMissionPackage) {
+        remotePackageProcessStatus = ""
+        isFinishedProcessingRemotePackage = false
         let requestURLString = "https://\(SettingsStore.global.takServerUrl):\(SettingsStore.global .takServerSecureAPIPort)\(AppConstants.MISSION_PACKAGE_FILE_PATH)/\(missionPackage.hash)"
         TAKLogger.debug("[DataPackageManager] Requesting file from \(requestURLString)")
         let requestUrl = URL(string: requestURLString)!
@@ -175,9 +179,12 @@ class DataPackageManager: NSObject, ObservableObject, URLSessionDelegate {
                 TAKLogger.debug("[DataPackageManager] File downloaded, starting import")
                 let parser = TAKDataPackageImporter(fileLocation: localURL, missionPackage: missionPackage)
                 parser.parse()
+                self.remotePackageProcessStatus = "Data package processed successfully!"
             } else {
                 self.logDataPackageManagerError(error.debugDescription)
+                self.remotePackageProcessStatus = "Data package could not be processed \(error.debugDescription)"
             }
+            self.isFinishedProcessingRemotePackage = true
         }
         task.resume()
     }

--- a/TAKAware/Communications/DataPackageManager.swift
+++ b/TAKAware/Communications/DataPackageManager.swift
@@ -1,0 +1,250 @@
+//
+//  DataPackageManager.swift
+//  TAKAware
+//
+//  Created by Cory Foy on 11/27/24.
+//
+
+import Foundation
+import SwiftTAK
+
+class TAKMissionPackage: Equatable {
+    var creator: String
+    var expiration: Date?
+    var groups: String
+    var hash: String
+    var keywords: String
+    var mimeType: String
+    var name: String
+    var size: String
+    var time: Date?
+    var user: String
+    
+    public init(
+        creator: String,
+        expiration: Date?,
+        groups: String,
+        hash: String,
+        keywords: String,
+        mimeType: String,
+        name: String,
+        size: String,
+        time: Date?,
+        user: String
+    ) {
+        self.creator = creator
+        self.expiration = expiration
+        self.groups = groups
+        self.hash = hash
+        self.keywords = keywords
+        self.mimeType = mimeType
+        self.name = name
+        self.size = size
+        self.time = time
+        self.user = user
+    }
+    
+    public static func == (lhs: TAKMissionPackage, rhs: TAKMissionPackage) -> Bool {
+        return lhs.hash == rhs.hash &&
+        lhs.creator == rhs.creator &&
+        lhs.expiration == rhs.expiration &&
+        lhs.groups == rhs.groups &&
+        lhs.keywords == rhs.keywords &&
+        lhs.mimeType == rhs.mimeType &&
+        lhs.name == rhs.name &&
+        lhs.size == rhs.size &&
+        lhs.time == rhs.time &&
+        lhs.user == rhs.user
+    }
+}
+
+class DataPackageManager: NSObject, ObservableObject, URLSessionDelegate {
+    @Published var dataPackages: [TAKMissionPackage] = []
+    @Published var isLoading = false
+    @Published var isSendingUpdate = false
+    let ANON_CHANNEL_NAME = "__ANON__"
+    
+    func retrieveDataPackages() {
+        if !isSendingUpdate {
+            isLoading = true
+        }
+        let requestURLString = "https://\(SettingsStore.global.takServerUrl):\(SettingsStore.global .takServerSecureAPIPort)\(AppConstants.MISSION_PACKAGE_LIST_PATH)"
+        TAKLogger.debug("[DataPackageManager] Requesting packages from \(requestURLString)")
+        let requestUrl = URL(string: requestURLString)!
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = 5
+        var request = URLRequest(url: requestUrl)
+        request.httpMethod = "get"
+
+        let session = URLSession(configuration: configuration,
+                                 delegate: self,
+                                 delegateQueue: OperationQueue.main)
+
+        let task = session.dataTask(with: request, completionHandler: { (data, response, error) in
+            TAKLogger.debug("[DataPackageManager] Session Data Task Returned...")
+            self.isLoading = false
+            self.isSendingUpdate = false
+            if error != nil {
+                self.logDataPackageManagerError(error!.localizedDescription)
+                return
+            }
+            guard let response = response as? HTTPURLResponse,
+                (200...299).contains(response.statusCode) else {
+                self.logDataPackageManagerError("Non success response code \((response as? HTTPURLResponse)?.statusCode.description ?? "UNKNOWN")")
+                return
+            }
+            if let mimeType = response.mimeType,
+                (mimeType == "application/json" || mimeType == "text/plain"),
+                let data = data {
+                self.storeDataPackageResponse(data)
+            } else {
+                self.logDataPackageManagerError("Unknown response from server when attempting package retrieval")
+            }
+        })
+
+        task.resume()
+    }
+    
+    /**
+     {
+         Creator = "";
+         Expiration = none;
+         Groups = "2024-State-Fair";
+         Hash = e652f29c0b8d5df59d8f29a57119ad8630deedea12715c0491a3fb6b3c54cda3;
+         Keywords = missionpackage;
+         MimeType = "application/x-zip-compressed";
+         Name = "FairPOIs.zip";
+         Size = 16kB;
+         Time = "2024-10-23 11:30:12.545";
+         User = "comm1.wcem";
+     }
+     */
+    
+    func storeDataPackageResponse(_ data: Data) {
+        TAKLogger.debug("[DataPackageManager] storeDataPackageResponse!")
+        dataPackages = []
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+
+        do {
+            if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
+                guard let packageList = json["data"] as? [[String: Any]] else { return }
+                for dataPackage in packageList {
+                    let creator: String = dataPackage["Creator"] as! String
+                    let expirationString: String = dataPackage["Expiration"] as! String
+                    let expiration: Date? = dateFormatter.date(from: expirationString)
+                    let groups: String = dataPackage["Groups"] as! String
+                    let hash: String = dataPackage["Hash"] as! String
+                    let keywords: String = dataPackage["Keywords"] as! String
+                    let mimeType: String = dataPackage["MimeType"] as! String
+                    let name: String = dataPackage["Name"] as! String
+                    let size: String = dataPackage["Size"] as! String
+                    let timeString: String = dataPackage["Time"] as! String
+                    let time: Date? = dateFormatter.date(from: timeString)
+                    let user: String = dataPackage["User"] as! String
+                    
+                    let dp = TAKMissionPackage(creator: creator, expiration: expiration, groups: groups, hash: hash, keywords: keywords, mimeType: mimeType, name: name, size: size, time: time, user: user)
+                    dataPackages.append(dp)
+                }
+            }
+        } catch {
+            TAKLogger.error("[DataPackageManager]: Error processing data package list response \(error)")
+        }
+    }
+    
+    func deletePackage(dataPackage: DataPackage) {
+        DataController.shared.deletePackage(dataPackage: dataPackage)
+    }
+    
+    func importRemotePackage(missionPackage: TAKMissionPackage) {
+        let requestURLString = "https://\(SettingsStore.global.takServerUrl):\(SettingsStore.global .takServerSecureAPIPort)\(AppConstants.MISSION_PACKAGE_FILE_PATH)/\(missionPackage.hash)"
+        TAKLogger.debug("[DataPackageManager] Requesting file from \(requestURLString)")
+        let requestUrl = URL(string: requestURLString)!
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = 5
+        
+        var request = URLRequest(url: requestUrl)
+        request.httpMethod = "get"
+
+        let session = URLSession(configuration: configuration,
+                                 delegate: self,
+                                 delegateQueue: OperationQueue.main)
+        
+        let task = session.downloadTask(with: requestUrl) { localURL, urlResponse, error in
+            if let localURL = localURL {
+                TAKLogger.debug("[DataPackageManager] File downloaded, starting import")
+                let parser = TAKDataPackageImporter(fileLocation: localURL, missionPackage: missionPackage)
+                parser.parse()
+            } else {
+                self.logDataPackageManagerError(error.debugDescription)
+            }
+        }
+        task.resume()
+    }
+    
+    func logDataPackageManagerError(_ err: String) {
+        TAKLogger.error("[DataPackageManager]: Error while trying to retrieve data packages \(err)")
+        isLoading = false
+        isSendingUpdate = false
+    }
+    
+    func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        
+        let authenticationMethod = challenge.protectionSpace.authenticationMethod
+
+        if authenticationMethod == NSURLAuthenticationMethodClientCertificate {
+            TAKLogger.error("[DataPackageManager]: Server requesting identity challenge")
+            guard let clientIdentity = SettingsStore.global.retrieveIdentity(label: SettingsStore.global.takServerUrl) else {
+                TAKLogger.error("[DataPackageManager]: Identity was not stored in the keychain")
+                completionHandler(.performDefaultHandling, nil)
+                return
+            }
+            
+            TAKLogger.error("[DataPackageManager]: Using client identity")
+            let credential = URLCredential(identity: clientIdentity,
+                                               certificates: nil,
+                                                persistence: .none)
+            challenge.sender?.use(credential, for: challenge)
+            completionHandler(.useCredential, credential)
+
+        } else if authenticationMethod == NSURLAuthenticationMethodServerTrust {
+            TAKLogger.debug("[DataPackageManager]: Server not trusted with default certs, seeing if we have custom ones")
+            
+            var optionalTrust: SecTrust?
+            var customCerts: [SecCertificate] = []
+
+            let trustCerts = SettingsStore.global.serverCertificateTruststore
+            TAKLogger.debug("[DataPackageManager]: Truststore contains \(trustCerts.count) cert(s)")
+            if !trustCerts.isEmpty {
+                TAKLogger.debug("[DataPackageManager]: Loading Trust Store Certs")
+                trustCerts.forEach { cert in
+                    if let convertedCert = SecCertificateCreateWithData(nil, cert as CFData) {
+                        customCerts.append(convertedCert)
+                    }
+                }
+            }
+            
+            if !customCerts.isEmpty {
+                TAKLogger.debug("[DataPackageManager]: We have custom certs, so disable hostname validation")
+                let sslWithoutHostnamePolicy = SecPolicyCreateSSL(true, nil)
+                let status = SecTrustCreateWithCertificates(customCerts as AnyObject,
+                                                            sslWithoutHostnamePolicy,
+                                                            &optionalTrust)
+                guard status == errSecSuccess else {
+                    completionHandler(.performDefaultHandling, nil)
+                    return
+                }
+            }
+
+            if optionalTrust != nil {
+                TAKLogger.debug("[DataPackageManager]: Retrying with local truststore")
+                let credential = URLCredential(trust: optionalTrust!)
+                challenge.sender?.use(credential, for: challenge)
+                completionHandler(.useCredential, credential)
+            } else {
+                TAKLogger.debug("[DataPackageManager]: No custom truststore ultimately found")
+                completionHandler(.performDefaultHandling, nil)
+            }
+        }
+    }
+}

--- a/TAKAware/Communications/DataSyncManager.swift
+++ b/TAKAware/Communications/DataSyncManager.swift
@@ -82,7 +82,7 @@ class DataSyncManager: NSObject, ObservableObject, URLSessionDelegate {
     
     func retrieveMissions() {
         isLoading = true
-        let requestURLString = "https://\(SettingsStore.global.takServerUrl):\(SettingsStore.global .takServerSecureAPIPort)\(AppConstants.DATA_PACKAGE_LIST_PATH)"
+        let requestURLString = "https://\(SettingsStore.global.takServerUrl):\(SettingsStore.global .takServerSecureAPIPort)\(AppConstants.DATA_SYNC_MISSION_LIST_PATH)"
         TAKLogger.debug("[DataSyncManager] Requesting data packages from \(requestURLString)")
         let requestUrl = URL(string: requestURLString)!
         let configuration = URLSessionConfiguration.default

--- a/TAKAware/Data Models/COTData.xcdatamodeld/COTData.xcdatamodel/contents
+++ b/TAKAware/Data Models/COTData.xcdatamodeld/COTData.xcdatamodel/contents
@@ -28,8 +28,10 @@
         <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="onReceiveDelete" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="onReceiveImport" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="originalFileHash" optional="YES" attributeType="String"/>
         <attribute name="remarks" optional="YES" attributeType="String"/>
         <attribute name="uid" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="user" optional="YES" attributeType="String"/>
         <relationship name="dataPackageFiles" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="DataPackageFile" inverseName="dataPackage" inverseEntity="DataPackageFile"/>
     </entity>
     <entity name="DataPackageFile" representedClassName="DataPackageFile" syncable="YES" codeGenerationType="class">

--- a/TAKAware/Data Models/TAKConstants.swift
+++ b/TAKAware/Data Models/TAKConstants.swift
@@ -27,8 +27,11 @@ struct AppConstants {
     static let CHANNELS_LIST_PATH = "/Marti/api/groups/all"
     static let CHANNELS_BIT_UPDATE_PATH = "/Marti/api/groups/activebits"
     
-    static let DATA_PACKAGE_LIST_PATH = "/Marti/api/missions"
-    static let DATA_PACKAGE_DETAILS_PATH = "/Marti/api/missions/{name}"
+    static let DATA_SYNC_MISSION_LIST_PATH = "/Marti/api/missions"
+    static let DATA_SYNC_MISSION_DETAILS_PATH = "/Marti/api/missions/{name}"
+    
+    static let MISSION_PACKAGE_LIST_PATH = "/Marti/api/files/metadata?missionPackage=true"
+    static let MISSION_PACKAGE_FILE_PATH = "/Marti/api/files" // Must append the hash to the end
     
     static let UDP_BROADCAST_URL = "239.2.3.1"
     

--- a/TAKAware/Screens/Sheets/DataPackageSheet.swift
+++ b/TAKAware/Screens/Sheets/DataPackageSheet.swift
@@ -61,8 +61,8 @@ struct DataPackageDownloader: View {
         .onAppear {
             dataPackageManager.retrieveDataPackages()
         }
-        .alert(isPresented: $isShowingAlert) {
-            Alert(title: Text("Data Package"), message: Text(alertText), dismissButton: .default(Text("OK")))
+        .alert(isPresented: $dataPackageManager.isFinishedProcessingRemotePackage) {
+            Alert(title: Text("Data Package"), message: Text(dataPackageManager.remotePackageProcessStatus), dismissButton: .default(Text("OK")))
         }
     }
 }

--- a/TAKAware/Screens/Sheets/DataPackageSheet.swift
+++ b/TAKAware/Screens/Sheets/DataPackageSheet.swift
@@ -9,15 +9,12 @@ import Foundation
 import SwiftTAK
 import SwiftUI
 
-struct DataPackageSheet: View {
-    @Environment(\.dismiss) var dismiss
+struct DataPackageDownloader: View {
     @StateObject var settingsStore: SettingsStore = SettingsStore.global
+    @StateObject var dataPackageManager: DataPackageManager = DataPackageManager()
     @State private var isRotating = 0.0
-    @State var isShowingFilePicker = false
     @State var isShowingAlert = false
     @State var alertText: String = ""
-    var dataContext = DataController.shared.backgroundContext
-    
     @FetchRequest(sortDescriptors: [SortDescriptor(\.createdAt, order: .reverse)])
     var dataPackages: FetchedResults<DataPackage>
     
@@ -26,80 +23,132 @@ struct DataPackageSheet: View {
             .rotationEffect(.degrees(isRotating))
             .onAppear {
                 withAnimation(.linear(duration: 1)
-                        .speed(0.1).repeatForever(autoreverses: false)) {
+                        .speed(0.4).repeatForever(autoreverses: false)) {
                     isRotating = 360.0
                 }
             }
     }
+    
+    var body: some View {
+        List {
+            if dataPackageManager.isLoading {
+                loader
+            } else {
+                ForEach(dataPackageManager.dataPackages, id:\.hash) { package in
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text(package.name)
+                            Text("\(package.size)")
+                                .font(.system(size: 10))
+                        }
+                        Spacer()
+                        Button {
+                            // On press, download the archive to the file system
+                            // Then start the data package importer pointed to the file
+                            dataPackageManager.importRemotePackage(missionPackage: package)
+                        } label: {
+                            if(dataPackages.contains(where: { $0.originalFileHash == package.hash })) {
+                                Image(systemName: "checkmark.circle.fill")
+                            } else {
+                                Image(systemName: "square.and.arrow.down")
+                            }
+                        }
+                        
+                    }
+                }
+            }
+        }
+        .onAppear {
+            dataPackageManager.retrieveDataPackages()
+        }
+        .alert(isPresented: $isShowingAlert) {
+            Alert(title: Text("Data Package"), message: Text(alertText), dismissButton: .default(Text("OK")))
+        }
+    }
+}
+
+struct DataPackageSheet: View {
+    @Environment(\.dismiss) var dismiss
+    @StateObject var settingsStore: SettingsStore = SettingsStore.global
+    @StateObject var dataPackageManager: DataPackageManager = DataPackageManager()
+    @State var isShowingFilePicker = false
+    @State var isShowingAlert = false
+    @State var alertText: String = ""
+    
+    @FetchRequest(sortDescriptors: [SortDescriptor(\.createdAt, order: .reverse)])
+    var dataPackages: FetchedResults<DataPackage>
 
     var body: some View {
         NavigationView {
             List {
-                VStack(alignment: .center) {
+                NavigationLink(destination: DataPackageDownloader()) {
+                    Text("Download from servers")
+                }
+                Button {
+                    isShowingFilePicker.toggle()
+                } label: {
                     HStack {
-                        Button {
-                            isShowingFilePicker.toggle()
-                        } label: {
-                            HStack {
-                                Text("Import a Data Package")
-                                Spacer()
-                                Image(systemName: "square.and.arrow.up")
-                                    .multilineTextAlignment(.trailing)
-                            }
-                            
-                        }
-                        .buttonStyle(.plain)
-                        
-                        .fileImporter(isPresented: $isShowingFilePicker, allowedContentTypes: [.zip], allowsMultipleSelection: false, onCompletion: { results in
-                            
-                            switch results {
-                            case .success(let fileurls):
-                                TAKLogger.debug("**SUCCESS")
-                                for fileurl in fileurls {
-                                    if(fileurl.startAccessingSecurityScopedResource()) {
-                                        TAKLogger.debug("Processing Package at \(String(describing: fileurl))")
-                                        let tdpi = TAKDataPackageImporter(
-                                            fileLocation: fileurl
-                                        )
-                                        tdpi.parse()
-                                        fileurl.stopAccessingSecurityScopedResource()
-                                        if(tdpi.parsingErrors.isEmpty) {
-                                            alertText = "Data package processed successfully!"
-                                        } else {
-                                            alertText = "Data package could not be processed\n\n\(tdpi.parsingErrors.joined(separator: "\n\n"))"
-                                        }
-                                        isShowingAlert = true
-                                    } else {
-                                        TAKLogger.error("Unable to securely access  \(String(describing: fileurl))")
-                                    }
-                                }
-                            case .failure(let error):
-                                TAKLogger.debug(String(describing: error))
-                            }
-                            
-                        })
+                        Text("Import a Data Package")
+                        Spacer()
+                        Image(systemName: "square.and.arrow.up")
+                            .multilineTextAlignment(.trailing)
                     }
-                    ForEach(dataPackages) { dataPackage in
-                        VStack {
+                    
+                }
+                .buttonStyle(.plain)
+                .fileImporter(isPresented: $isShowingFilePicker, allowedContentTypes: [.zip], allowsMultipleSelection: false, onCompletion: { results in
+                    
+                    switch results {
+                    case .success(let fileurls):
+                        for fileurl in fileurls {
+                            if(fileurl.startAccessingSecurityScopedResource()) {
+                                TAKLogger.debug("Processing Package at \(String(describing: fileurl))")
+                                let tdpi = TAKDataPackageImporter(
+                                    fileLocation: fileurl
+                                )
+                                tdpi.parse()
+                                fileurl.stopAccessingSecurityScopedResource()
+                                if(tdpi.parsingErrors.isEmpty) {
+                                    alertText = "Data package processed successfully!"
+                                } else {
+                                    alertText = "Data package could not be processed\n\n\(tdpi.parsingErrors.joined(separator: "\n\n"))"
+                                }
+                                isShowingAlert = true
+                            } else {
+                                TAKLogger.error("Unable to securely access  \(String(describing: fileurl))")
+                            }
+                        }
+                    case .failure(let error):
+                        TAKLogger.debug(String(describing: error))
+                    }
+                    
+                })
+                Section(header: Text("Imported Packages")) {
+                    if dataPackages.isEmpty {
+                        Text("No Data Packages Imported")
+                    } else {
+                        ForEach(dataPackages) { dataPackage in
                             HStack {
-                                Image(systemName: "eye.fill")
                                 Image(systemName: "shippingbox")
                                 VStack(alignment: .leading) {
                                     Text(dataPackage.name ?? "Unknown Name")
                                         .fontWeight(.bold)
-                                    Text("\(SettingsStore.global.callSign), 9 items")
+                                    Text("\(dataPackage.user!), \(dataPackage.dataPackageFiles!.count) item(s)")
+                                        .font(.system(size: 8))
                                 }
                                 Spacer()
-                                Image(systemName: "arrow.up.square.fill")
-                                Image(systemName: "trash.square")
+                                Button {
+                                    dataPackageManager.deletePackage(dataPackage: dataPackage)
+                                } label: {
+                                    Image(systemName: "trash.square")
+                                }
                             }
                         }
-                        .padding(.top, 20)
                     }
                 }
-                .alert(isPresented: $isShowingAlert) {
-                    Alert(title: Text("Data Package"), message: Text(alertText), dismissButton: .default(Text("OK")))
-                }
+            }
+            .alert(isPresented: $isShowingAlert) {
+                Alert(title: Text("Data Package"), message: Text(alertText), dismissButton: .default(Text("OK")))
             }
             .navigationTitle("Data Packages")
             .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
- Closes #32 
- Closes #14 
- Makes progress towards #13 

This PR allows users to download remote data packages from the server, and adds basic management to view the list of files imported as well as delete the package (which deletes all associated CoT markers). Still need to add in the ability to turn on/off the visibility of the data package and associated markers, as well as open individual non-CoT files (or scroll the map to CoT markers). 