### PR TITLE
Background Processing Updates

### DIFF
--- a/TAKAware.xcodeproj/project.pbxproj
+++ b/TAKAware.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		A595F66A2C278CFE00E81976 /* Components.swift in Sources */ = {isa = PBXBuildFile; fileRef = A595F6692C278CFE00E81976 /* Components.swift */; };
 		A59C08472AACF95100C33B44 /* CertificateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59C08462AACF95100C33B44 /* CertificateManager.swift */; };
 		A5A30D572D280F88009399F3 /* KMLData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A30D562D280F84009399F3 /* KMLData.swift */; };
+		A5A30D592D2A431E009399F3 /* COTData+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A30D582D2A4318009399F3 /* COTData+Extension.swift */; };
 		A5A49D902A5459B5009764C1 /* TAKManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A49D8F2A5459B5009764C1 /* TAKManager.swift */; };
 		A5AA510A2AC33488006696B2 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5AA51092AC33488006696B2 /* OnboardingView.swift */; };
 		A5AA510F2AC35B75006696B2 /* SettingsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5AA510E2AC35B75006696B2 /* SettingsStoreTests.swift */; };
@@ -3503,6 +3504,7 @@
 		A599D66C2A5E45CD00B507D9 /* TAKAware.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TAKAware.entitlements; sourceTree = "<group>"; };
 		A59C08462AACF95100C33B44 /* CertificateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificateManager.swift; sourceTree = "<group>"; };
 		A5A30D562D280F84009399F3 /* KMLData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KMLData.swift; sourceTree = "<group>"; };
+		A5A30D582D2A4318009399F3 /* COTData+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "COTData+Extension.swift"; sourceTree = "<group>"; };
 		A5A49D8F2A5459B5009764C1 /* TAKManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TAKManager.swift; sourceTree = "<group>"; };
 		A5A49D912A547378009764C1 /* TAKAware-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "TAKAware-Info.plist"; sourceTree = SOURCE_ROOT; };
 		A5AA51092AC33488006696B2 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
@@ -6904,6 +6906,7 @@
 		4630FD152B5071BD00988ED4 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				A5A30D582D2A4318009399F3 /* COTData+Extension.swift */,
 				A52BE9082D17E01000E82414 /* KMLFile+Extension.swift */,
 				4630FD162B5071BD00988ED4 /* String+Extension.swift */,
 				A5B1FF632C3B86D600C7F546 /* UIImage+Extension.swift */,
@@ -14061,6 +14064,7 @@
 				A5E2D0BD2C3F218B009FCD51 /* ChannelManager.swift in Sources */,
 				A55ABF452ABDBF9A00195AB7 /* UserInformation.swift in Sources */,
 				A578E42E2C550FD8001978D4 /* MapView.swift in Sources */,
+				A5A30D592D2A431E009399F3 /* COTData+Extension.swift in Sources */,
 				A50C5F5F2A6032D2001E52E6 /* EmergencyView.swift in Sources */,
 				A59C08472AACF95100C33B44 /* CertificateManager.swift in Sources */,
 				A50C5F5D2A601CF0001E52E6 /* SettingsView.swift in Sources */,
@@ -14251,7 +14255,7 @@
 				CODE_SIGN_ENTITLEMENTS = TAKAware/TAKAware.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 74;
+				CURRENT_PROJECT_VERSION = 75;
 				DEVELOPMENT_ASSET_PATHS = "TAKAware/Preview\\ Content";
 				DEVELOPMENT_TEAM = 28788VBS76;
 				ENABLE_PREVIEWS = YES;
@@ -14295,7 +14299,7 @@
 				CODE_SIGN_ENTITLEMENTS = TAKAware/TAKAware.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 74;
+				CURRENT_PROJECT_VERSION = 75;
 				DEVELOPMENT_ASSET_PATHS = "TAKAware/Preview\\ Content";
 				DEVELOPMENT_TEAM = 28788VBS76;
 				ENABLE_PREVIEWS = YES;
@@ -14335,7 +14339,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 74;
+				CURRENT_PROJECT_VERSION = 75;
 				DEVELOPMENT_TEAM = 5LZ5HR44P3;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -14356,7 +14360,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 74;
+				CURRENT_PROJECT_VERSION = 75;
 				DEVELOPMENT_TEAM = 5LZ5HR44P3;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -14375,7 +14379,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 74;
+				CURRENT_PROJECT_VERSION = 75;
 				DEVELOPMENT_TEAM = 5LZ5HR44P3;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.1;
@@ -14392,7 +14396,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 74;
+				CURRENT_PROJECT_VERSION = 75;
 				DEVELOPMENT_TEAM = 5LZ5HR44P3;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.1;

--- a/TAKAware/Data Models/TAKConstants.swift
+++ b/TAKAware/Data Models/TAKConstants.swift
@@ -44,6 +44,12 @@ struct AppConstants {
     static let NOTIFY_KML_FILE_ADDED = "KMLFileAdded"
     static let NOTIFY_KML_FILE_UPDATED = "KMLFileUpdated"
     static let NOTIFY_KML_FILE_REMOVED = "KMLFileRemoved"
+    static let NOTIFY_COT_ADDED = "COTAdded"
+    static let NOTIFY_COT_UPDATED = "COTUpdated"
+    static let NOTIFY_COT_REMOVED = "COTRemoved"
+    static let NOTIFY_APP_ACTIVE = "AppScenePhaseActive"
+    static let NOTIFY_APP_INACTIVE = "AppScenePhaseInactive"
+    static let NOTIFY_APP_BACKGROUND = "AppScenePhaseBackground"
     
     static let DIRECTORY_OVERLAYS = "overlays"
     static let DIRECTORY_DATA_PACKAGES = "datapackages"

--- a/TAKAware/Extensions/COTData+Extension.swift
+++ b/TAKAware/Extensions/COTData+Extension.swift
@@ -1,0 +1,15 @@
+//
+//  COTData+Extension.swift
+//  TAKAware
+//
+//  Created by Cory Foy on 1/4/25.
+//
+
+import Foundation
+
+extension COTData {
+    public override func didSave() {
+        super.didSave()
+        NotificationCenter.default.post(name: Notification.Name(AppConstants.NOTIFY_COT_UPDATED), object: nil)
+    }
+}

--- a/TAKAware/LocationManager.swift
+++ b/TAKAware/LocationManager.swift
@@ -14,8 +14,6 @@ class LocationManager: NSObject,CLLocationManagerDelegate, ObservableObject {
     @Published var locationStatus: CLAuthorizationStatus?
     @Published var lastLocation: CLLocation?
     @Published var lastHeading: CLHeading?
-    
-    var shouldUpdateCoordinateRegion = true
 
     private let manager = CLLocationManager()
 
@@ -65,13 +63,11 @@ class LocationManager: NSObject,CLLocationManagerDelegate, ObservableObject {
         guard let location = locations.last else { TAKLogger.debug("No Locations!"); return }
         lastLocation = location
         
-        if(shouldUpdateCoordinateRegion) {
-            locations.last.map {
-                region = MKCoordinateRegion(
-                    center: CLLocationCoordinate2D(latitude: $0.coordinate.latitude, longitude: $0.coordinate.longitude),
-                    span: MKCoordinateSpan(latitudeDelta: 0.5, longitudeDelta: 0.5)
-                )
-            }
+        locations.last.map {
+            region = MKCoordinateRegion(
+                center: CLLocationCoordinate2D(latitude: $0.coordinate.latitude, longitude: $0.coordinate.longitude),
+                span: MKCoordinateSpan(latitudeDelta: 0.5, longitudeDelta: 0.5)
+            )
         }
         
         guard let heading = manager.heading else { TAKLogger.debug("No heading!"); return }

--- a/TAKAware/Screens/Sheets/DataPackageSheet.swift
+++ b/TAKAware/Screens/Sheets/DataPackageSheet.swift
@@ -198,7 +198,7 @@ struct DataPackageDetail: View {
             })
             Section(
                 header: Text("Imported Packages"),
-                footer: Text("Swipe a package to manage. Note that KML/KMZ import is not supported at this time")
+                footer: Text("Swipe a package to manage")
             ) {
                 if dataPackages.isEmpty {
                     Text("No Data Packages Imported")

--- a/TAKAware/Screens/TAKAwareApp.swift
+++ b/TAKAware/Screens/TAKAwareApp.swift
@@ -55,12 +55,15 @@ struct TAKTrackerApp: App {
                     .onChange(of: scenePhase) { newPhase in
                         if newPhase == .inactive {
                             TAKLogger.debug("[ScenePhase] Moving to inactive")
+                            NotificationCenter.default.post(name: Notification.Name(AppConstants.NOTIFY_APP_INACTIVE), object: nil)
                             settingsStore.shouldTryReconnect = true
                         } else if newPhase == .active {
                             TAKLogger.debug("[ScenePhase] Moving to active")
+                            NotificationCenter.default.post(name: Notification.Name(AppConstants.NOTIFY_APP_ACTIVE), object: nil)
                             settingsStore.shouldTryReconnect = true
                         } else if newPhase == .background {
                             TAKLogger.debug("[ScenePhase] Moving to background")
+                            NotificationCenter.default.post(name: Notification.Name(AppConstants.NOTIFY_APP_BACKGROUND), object: nil)
                             settingsStore.shouldTryReconnect = true
                         }
                     }


### PR DESCRIPTION
With newer builds the app was getting suspended when in the background. This was due to the app being in a tight loop for updateUIView to query the DB for changes. This modifies the approach to be notification based, and also to not update the map when it is in the background.