### PR TITLE
Allows user to toggle showing the full label on map items

### DIFF
--- a/TAKAware/Data Models/SettingsStore.swift
+++ b/TAKAware/Data Models/SettingsStore.swift
@@ -10,6 +10,12 @@ import MapKit
 import SwiftTAK
 import UIKit
 
+enum MapLabelDisplayOption: Int {
+    case Truncate
+    case ShowFullLabel
+    case Scroll
+}
+
 class SettingsStore: ObservableObject {
     static let global = SettingsStore()
     
@@ -293,12 +299,27 @@ class SettingsStore: ObservableObject {
             DataController.shared.clearTransientItems()
         }
     }
+    
+    @Published var mapLabelDisplayOption: MapLabelDisplayOption {
+        didSet {
+            UserDefaults.standard.set(mapLabelDisplayOption.rawValue, forKey: "mapLabelDisplayOption")
+        }
+    }
+    
+    var mapLabelShouldTruncate: Bool {
+        get { mapLabelDisplayOption == .Truncate }
+        set {
+            mapLabelDisplayOption = newValue ? MapLabelDisplayOption.Truncate : MapLabelDisplayOption.ShowFullLabel
+        }
+    }
 
     private init() {
         let defaultSign = SettingsStore.generateDefaultCallSign()
         self.lastAppVersionRun = (UserDefaults.standard.object(forKey: "lastAppVersionRun") == nil ? "" : UserDefaults.standard.object(forKey: "lastAppVersionRun") as! String)
         
         self.enable2525ForRoles = (UserDefaults.standard.object(forKey: "enable2525ForRoles") == nil ? false : UserDefaults.standard.object(forKey: "enable2525ForRoles") as! Bool)
+        
+        self.mapLabelDisplayOption = (UserDefaults.standard.object(forKey: "mapLabelDisplayOption") == nil ? .Truncate : MapLabelDisplayOption(rawValue: UserDefaults.standard.object(forKey: "mapLabelDisplayOption") as! Int) ?? .Truncate)
         
         self.enableTrafficDisplay = (UserDefaults.standard.object(forKey: "enableTrafficDisplay") == nil ? true : UserDefaults.standard.object(forKey: "enableTrafficDisplay") as! Bool)
         

--- a/TAKAware/Screens/MainScreens/MapView.swift
+++ b/TAKAware/Screens/MainScreens/MapView.swift
@@ -420,7 +420,10 @@ class SituationalAnnotationView: MKAnnotationView {
         annotationLabel.sizeToFit()
         annotationLabel.preferredMaxLayoutWidth = 70
         let afterReframe = annotationLabel.frame
-        let newWidth = (afterReframe.width > 70) ? 70 : afterReframe.width
+        var newWidth = afterReframe.width
+        if SettingsStore.global.mapLabelDisplayOption == .Truncate {
+            newWidth = (afterReframe.width > 70) ? 70 : afterReframe.width
+        }
         let xPos = -(newWidth/2) + 15
         annotationLabel.frame = CGRect(x: xPos, y: -10, width: newWidth, height: afterReframe.height)
         self.addSubview(annotationLabel)

--- a/TAKAware/Screens/SettingsScreens/MapOptions.swift
+++ b/TAKAware/Screens/SettingsScreens/MapOptions.swift
@@ -88,10 +88,11 @@ struct MapOptions: View {
                     }
                 }
                 
-                Section(header: Text("Map Options"), footer: Text("Will cause a map refresh when toggled")) {
+                Section(header: Text("Map Options"), footer: Text("May cause a map refresh when toggled")) {
                     List {
                         Toggle("Show traffic when available", isOn: $settingsStore.enableTrafficDisplay)
                         Toggle("Show Contacts as 2525 Icons", isOn: $settingsStore.enable2525ForRoles)
+                        Toggle("Truncate Map Labels", isOn: $settingsStore.mapLabelShouldTruncate)
                     }
                 }
                 


### PR DESCRIPTION
Closes #50 by allowing the user to toggle on/off whether to truncate labels. By default they will be truncated (which is the current behavior). We will eventually add the scrolling option ala ATAK but that will be further down the line.