### PR TITLE
Updates call options to support copying and texting

### DIFF
--- a/TAKAware/Data Models/TAKConstants.swift
+++ b/TAKAware/Data Models/TAKConstants.swift
@@ -58,6 +58,7 @@ struct AppConstants {
     static let NOTIFY_SCROLL_TO_KML = "ScrollToKML"
     static let NOTIFY_MAP_SOURCE_UPDATED = "MapSourceUpdated"
     static let NOTIFY_SERVER_CONNECTED = "TAKServerConnected"
+    static let NOTIFY_PHONE_ACTION_REQUESTED = "PhoneActionRequested"
     
     static func appDirectoryFor(_ directory: AppDirectories) -> URL {
         let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!

--- a/TAKAware/Screens/MainScreens/MapView.swift
+++ b/TAKAware/Screens/MainScreens/MapView.swift
@@ -484,16 +484,12 @@ class SituationalAnnotationView: MKAnnotationView {
         self.detailCalloutAccessoryView = actionView
     }
     
-    // TODO: Do something meaningful on devices that can't make calls (like iPads)
-    // TODO: Enable the menu to copy the number or send a text
     @objc func makeCall(sender: UIButton) {
         guard let phone = mapPointAnnotation.phone else {
             TAKLogger.error("[MapView] Attempted to make a phone call with no annotation / phone")
             return
         }
-        if let telUrl = URL(string: "tel://\(phone)") {
-            UIApplication.shared.open(telUrl, options: [:])
-        }
+        NotificationCenter.default.post(name: Notification.Name(AppConstants.NOTIFY_PHONE_ACTION_REQUESTED), object: phone)
     }
     
     @objc func videoPressed(sender: UIButton) {


### PR DESCRIPTION
Closes #86 and closes #87 by adding multiple options when a user clicks on the phone contact of the CoT user menu. The user will always be able to copy the number, and if texting and/or calling are supported than those options will be presented in the menu as well.