### PR TITLE
Fixes issue with cert enrollment when response is xml instead of plain

### DIFF
--- a/TAKAware/Communications/CSRRequestor.swift
+++ b/TAKAware/Communications/CSRRequestor.swift
@@ -302,7 +302,7 @@ class CSRRequestor: NSObject, ObservableObject, URLSessionDelegate {
                 return
             }
             if let mimeType = response.mimeType,
-                mimeType == "text/plain",
+                (mimeType == "text/plain" || mimeType == "application/xml"),
                 let data = data,
                 let dataString = String(data: data, encoding: .utf8) {
                 self.processConfigResponse(data: data, dataString: dataString)


### PR DESCRIPTION
Closes issue #132 

TPC TAK returns `text/plain` to the TLS Configuration Variables call, but it actually returns XML. So when OpenTAKServer (properly) responds with `application/xml` as the mime type, we were rejecting the response.